### PR TITLE
fix: typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ramalama==0.7.5
-lama-stack>=0.1.8
+llama-stack>=0.1.8
 llama-stack-client>=0.1.8


### PR DESCRIPTION
Missing an `l`